### PR TITLE
Significantly improved performace. Fixed backwards animations. Refact…

### DIFF
--- a/Assets/Scenes/New Scene.unity
+++ b/Assets/Scenes/New Scene.unity
@@ -1,0 +1,316 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &625362211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625362214}
+  - component: {fileID: 625362213}
+  - component: {fileID: 625362212}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &625362212
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625362211}
+  m_Enabled: 1
+--- !u!20 &625362213
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625362211}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &625362214
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625362211}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1054182317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1054182319}
+  - component: {fileID: 1054182318}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1054182318
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1054182317}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1054182319
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1054182317}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 625362214}
+  - {fileID: 1054182319}

--- a/Assets/Scenes/New Scene.unity.meta
+++ b/Assets/Scenes/New Scene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 350940146a92e7a4e998ba4dde666f2f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2308,7 +2308,7 @@ MonoBehaviour:
   dontDestroyOnLoad: 0
   lineStarOffset: 2
   lineWidth: 1.68
-  animationDuration: 0.7
+  animationDuration: 0.13
   constallationPrefab: {fileID: 1260849906208590709, guid: d2a70c6596ed7724db97dba3746c881d, type: 3}
   constallationInstanceInfo:
   - JsonAsset: {fileID: 4900000, guid: 998b8ea5b359c104fb18dea723f3fad6, type: 3}

--- a/Assets/_Prefabs/Constellation.prefab
+++ b/Assets/_Prefabs/Constellation.prefab
@@ -81,8 +81,8 @@ MonoBehaviour:
   starPrefab: {fileID: 850808899683947902, guid: d3380005a22335c408cc16cd212c8136, type: 3}
   GFX: {fileID: 3923539755319211181}
   rend: {fileID: 2061812272309427382}
-  JsonAsset: {fileID: 0}
   linePrefab: {fileID: 1869456495877735470, guid: 4cdc70ee4fa4d6044a078180cac8b660, type: 3}
+  meshCombinerPrefab: {fileID: 4257185240971833086, guid: d71d4d32a0b6b184881142d3b6ce9a8a, type: 3}
 --- !u!1 &5522472048556539124
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/ConstellationDisplay.cs
+++ b/Assets/__Scripts/ConstellationDisplay.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections;
 using UnityEngine;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,68 +7,63 @@ using System;
 
 public class ConstellationDisplay : MonoBehaviour
 {
-	[SerializeField, Tooltip("Lines will stretch instead of fading")] private bool stretchAnimationMode;
 	[SerializeField] private StarDisplay starPrefab;
 	[SerializeField] private Transform GFX;
 	[SerializeField] private Renderer rend;
 	[SerializeField] private LineController linePrefab;
+	[SerializeField] private MeshCombiner meshCombinerPrefab;
 
 	public int LineRendererCount => lines.Count;
-	public Dictionary<int, LineController> UsedLines;
 
 	private ConstellationData constellationData;
-	private List<StarDisplay> stars;
-	private List<LineController> lines;
-	private Transform starsParent;
 	private StarDisplay centerMostStar;
-	
+
+	private List<LineController> lines;
+	public Dictionary<int, LineController> UsedLines;
+	public SortedDictionary<int, List<LineController>> LineAnimationGroups;
+
+	private Dictionary<int, StarDisplay> dynamicStars;
+	private Transform linesParent;
+	private Transform dynamicStarsParent;
+
 	private bool isImageEnabled;
 	private bool isLinesEnabled;
-	private bool isAnimatingLines;
+	private bool isOpeningLines;
+	private bool isClosingLines;
+	private bool linesToggler;
 	private bool isAnimatingImage;
 
 	private bool breakAsync;
 
-
 	private void Awake()
 	{
-		stars = new List<StarDisplay>();
 		lines = new List<LineController>();
 		UsedLines = new Dictionary<int, LineController>();
-		starsParent = new GameObject().transform;
-		starsParent.SetParent(transform.parent);
+		LineAnimationGroups = new SortedDictionary<int, List<LineController>>();
+		dynamicStars = new Dictionary<int, StarDisplay>();
 	}
 
 	public void Init(ConstellationInstanceInfo instanceInfo)
 	{
 		// Инициализируем созвездие
 		constellationData = JsonUtility.FromJson<JsonData>(instanceInfo.JsonAsset.text).items[0];
-		rend.material = instanceInfo.Material;
+		rend.sharedMaterial = instanceInfo.Material;
 		var cam = Camera.main;
-		SetupTransform(cam.transform);
+		SetupTransform(constellationData, cam.transform);
 		var color = rend.material.color;
 		color.a = 0;
 		rend.material.color = color; // rend - отображает изображение созвездия. По умолчанию оно выключено
+		rend.gameObject.SetActive(false);
 
-		// Создаем звезды
-		foreach (var starData in constellationData.stars)
-		{
-			StarDisplay starDisplay = Instantiate(starPrefab, starsParent.transform);
-			starDisplay.Init(starData, this, cam.transform);
-			stars.Add(starDisplay);
-		}
+		CreateStars(cam.transform);
 
-		// Находим самую центральную звезду
-		centerMostStar = stars.Aggregate((minStar, nextStar) =>
-			(constellationData.WorldPos - nextStar.data.WorldPos).magnitude < (constellationData.WorldPos - minStar.data.WorldPos).magnitude ? nextStar : minStar);
-
-		// Создаем соединяющие линии созвездий
-		foreach (var connection in constellationData.pairs)
-		{
-			CreateLine(stars.First(star => star.data.id == connection.from), 
-						stars.First(star => star.data.id == connection.to));
-		}
+		centerMostStar = dynamicStars.Aggregate((minStar, nextStar) =>
+			(constellationData.WorldPos - nextStar.Value.data.WorldPos).magnitude <
+			(constellationData.WorldPos - minStar.Value.data.WorldPos).magnitude ?
+			nextStar : minStar)
+			.Value;
 	}
+
 	public void UpdateLinesWidth()
 	{
 		// Метод для редактирования толщины линии в рантайме
@@ -85,35 +81,95 @@ public class ConstellationDisplay : MonoBehaviour
 		if (isAnimatingImage)
 			return;
 		isAnimatingImage = true;
-		
+		if (isImageEnabled == false)
+			rend.gameObject.SetActive(true);
+
+
 		StartCoroutine(Helper.FadeAnimation(rend, ConstellationManager.Instance.AnimationDuration, !isImageEnabled, OnComplete: () => 
-		{ 
+		{
 			isImageEnabled = !isImageEnabled;
+			if (isImageEnabled == false)
+				rend.gameObject.SetActive(false);
 			isAnimatingImage = false;
 			OnComplete?.Invoke();
 		}));
 	}
 
-	public void AnimateLines(Action OnComplete = null)
-	{
-		// Анимация линий созвездия
-		if (isAnimatingLines)
-			return;
-		isAnimatingLines = true;
 
-		ActivateLinesAnimationAsync(OnComplete);
+	public void ToggleAnimations()
+	{
+		if (linesToggler)
+		{
+			AnimateLinesClose();
+		}
+		else
+		{
+			AnimateLinesOpen();
+		}
 	}
 
-	public void RevertAnimation()
+	public void AnimateLinesOpen(Action OnComplete = null) => AnimateLinesOpenAsync(OnComplete);
+	public void AnimateLinesClose(Action OnComplete = null) => StartCoroutine(AnimateLinesCloseCoroutine(OnComplete));
+
+	#region Private Methods
+
+	private async void AnimateLinesOpenAsync(Action OnComplete = null)
+	{       
+		// Анимация линий созвездия
+		if (isOpeningLines || isLinesEnabled || isClosingLines)
+			return;
+
+		dynamicStarsParent.gameObject.SetActive(true);
+		linesParent.gameObject.SetActive(true);
+		isOpeningLines = true;
+		linesToggler = true;
+
+		// Асинхронный метод для последовательной анимации (без рекурсии)
+		int animationGroup = 0;
+		List<StarDisplay> animatingBatch = await centerMostStar.AnimateAllNeighboursAsync(animationGroup); // Начинаем с самой центральной звезды
+		List<Task<List<StarDisplay>>> tasks = new List<Task<List<StarDisplay>>>(); // Список всех тасков для синхронной анимации
+
+		while (true)
+		{
+			if (breakAsync)
+				break;
+
+			animationGroup++;
+			foreach (var star in animatingBatch)
+			{
+				var item = star.AnimateAllNeighboursAsync(animationGroup);
+				tasks.Add(item);
+			}
+
+			// Если тасков не получено, значит анимации закончились
+			if (tasks.Count == 0)
+				break;
+
+			await Task.WhenAll(tasks);
+
+			animatingBatch.Clear(); // Удаляем уже анимированные звезды
+			foreach (var task in tasks)
+				animatingBatch.AddRange(task.Result); // Добавляем новые (те, что соединены с теми, которые были удалены)
+
+			tasks.Clear();
+		}
+
+		isOpeningLines = false;
+		isLinesEnabled = true;
+		OnComplete?.Invoke();
+	}
+
+	private IEnumerator AnimateLinesCloseCoroutine(Action OnComplete = null)
 	{
 		// Разворот анимации
-		if (UsedLines.Count == 0)
-			return;
-		isAnimatingLines = true;
+		if (LineAnimationGroups.Count == 0 || UsedLines.Count == 0 || isClosingLines)
+			yield break;
+
+		isClosingLines = true;
 
 		// Останавливаем текущие анимации
 		breakAsync = true;
-		foreach (var star in stars)
+		foreach (var star in dynamicStars.Values)
 		{
 			star.StopAllCoroutines();
 			star.ResetScale();
@@ -123,78 +179,36 @@ public class ConstellationDisplay : MonoBehaviour
 
 		// Создаем обратные анимации на тех объектах, которые успели закончить свою анимацию
 		var animDuration = ConstellationManager.Instance.AnimationDuration;
-		foreach (var line in UsedLines.Values)
+		List<LineController> group;
+		for (var i = LineAnimationGroups.Count - 1; i >= 0; i--)
 		{
-			if (stretchAnimationMode)
+			group = LineAnimationGroups[i];
+			foreach (var line in group)
 			{
 				line.RevertTarget();
-				line.StretchLine(animDuration, () =>
-				{
-					OnRevertComplete(line);
-				});
+				line.StretchLine(animDuration, () => line.IsEnabled = false);
 			}
-			else
-			{
-				line.StartCoroutine(Helper.FadeAnimation(line.lineRenderer, animDuration, false, OnComplete: () =>
-				{
-					OnRevertComplete(line);
-				}));
-			}
+
+			yield return new WaitForSeconds(animDuration);
 		}
 
-		void OnRevertComplete(LineController line)
-		{
-			// OnComplete
-			line.IsEnabled = false;
-			isAnimatingLines = false;
-			isLinesEnabled = false;
-			breakAsync = false;
-			UsedLines.Clear();
-		}
-	}
-
-	private async void ActivateLinesAnimationAsync(Action OnComplete = null)
-	{
-		if (isLinesEnabled)
-			return;
-
-		// Асинхронный метод для последовательной анимации (без рекурсии)
-		List<StarDisplay> animatingBatch = await centerMostStar.AnimateAllNeighboursAsync(stretchAnimationMode); // Начинаем с самой центральной звезды
-		List<Task<List<StarDisplay>>> tasks = new List<Task<List<StarDisplay>>>(); // Список всех тасков для синхронной анимации
-
-		while (true)
-		{
-			if (breakAsync)
-				break;
-
-			foreach (var star in animatingBatch)
-			{
-				var item = star.AnimateAllNeighboursAsync(stretchAnimationMode);
-				tasks.Add(item);
-			}
-			
-			// Если тасков не получено, значит анимации закончились
-			if (tasks.Count == 0)
-				break;
-
-			await Task.WhenAll(tasks);
-
-			animatingBatch.Clear(); // Удаляем уже анимированные звезды
-			foreach (var task in tasks) 
-				animatingBatch.AddRange(task.Result); // Добавляем новые (те, что соединены с теми, которые были удалены)
-
-			tasks.Clear();
-		}
-
-		isAnimatingLines = false;
-		isLinesEnabled = true;
+		isOpeningLines = false;
+		isLinesEnabled = false;
+		isClosingLines = false;
+		breakAsync = false;
+		linesToggler = false;
+		LineAnimationGroups.Clear();
+		UsedLines.Clear();
 		OnComplete?.Invoke();
+		linesParent.gameObject.SetActive(false);
+		dynamicStarsParent.gameObject.SetActive(false);
 	}
 
-	private void SetupTransform(Transform camTransform)
+	private void SetupTransform(ConstellationData constellationData, Transform camTransform)
 	{
 		// Настраиваем трансформ для корректного расположения созвездия на небесной сфере
 		transform.position = constellationData.WorldPos;
+		GFX.name = constellationData.name + "_Image";
 		GFX.LookAt(camTransform);
 		camTransform.LookAt(GFX);
 		GFX.transform.position = constellationData.ImagePos;
@@ -206,9 +220,8 @@ public class ConstellationDisplay : MonoBehaviour
 	private void CreateLine(StarDisplay fromStarDisplay, StarDisplay toStarDisplay)
 	{
 		// Создаем нужное кол-во линий (по-умолчанию выключены)
-
-		var line = Instantiate(linePrefab, transform);
-		line.Init(stretchAnimationMode);
+		var line = Instantiate(linePrefab, linesParent);
+		line.Init();
 
 		line.CalcPositions(fromStarDisplay, toStarDisplay);
 		line.SetPosition();
@@ -217,4 +230,63 @@ public class ConstellationDisplay : MonoBehaviour
 		toStarDisplay.AddConnection(line, fromStarDisplay);
 		lines.Add(line);
 	}
+
+	private void CreateStars(Transform lookAt)
+	{
+		CreateDynamicStars(lookAt);
+		CreateStaticStars(lookAt);
+	}
+
+	private void CreateDynamicStars(Transform lookAt)
+	{
+		// Создаем "динамические" звезды (которые участвуют в анимациях = части созвездий)
+		dynamicStarsParent = new GameObject().transform;
+		dynamicStarsParent.SetParent(transform);
+		dynamicStarsParent.name = constellationData.name + "-Stars-Dynamic";
+		dynamicStarsParent.gameObject.SetActive(false);
+
+		linesParent = new GameObject("Lines").transform;
+		linesParent.SetParent(transform); 
+		linesParent.gameObject.SetActive(false);
+
+
+		foreach (var connection in constellationData.pairs)
+		{
+			var fromStarData = constellationData.stars.First(star => star.id == connection.from);
+			var toStarData = constellationData.stars.First(star => star.id == connection.to);
+
+			if (!dynamicStars.ContainsKey(fromStarData.id))
+			{
+				StarDisplay starDisplay = Instantiate(starPrefab, dynamicStarsParent.transform);
+				starDisplay.Init(fromStarData, this, lookAt);
+				dynamicStars.Add(fromStarData.id, starDisplay);
+			}
+
+			if (!dynamicStars.ContainsKey(toStarData.id))
+			{
+				StarDisplay starDisplay = Instantiate(starPrefab, dynamicStarsParent.transform);
+				starDisplay.Init(toStarData, this, lookAt);
+				dynamicStars.Add(toStarData.id, starDisplay);
+			}
+
+			// Создаем соединяющие линии созвездий
+			CreateLine(dynamicStars[fromStarData.id], dynamicStars[toStarData.id]);
+		}
+	}
+
+	private void CreateStaticStars(Transform lookAt)
+	{
+		// Создаем и объединяем статические звезды
+		var meshCombiner = Instantiate(meshCombinerPrefab, transform);
+		meshCombiner.name = constellationData.name + "-Stars-Static";
+		foreach (var starData in constellationData.stars)
+		{
+			StarDisplay starDisplay = Instantiate(starPrefab, meshCombiner.transform);
+			starDisplay.Init(starData, this, lookAt);
+			meshCombiner.Add(starDisplay.MeshSchemaIndex, starDisplay.meshFilter);
+		}
+		meshCombiner.CombineAllMeshes();
+	}
+
+	#endregion
 }

--- a/Assets/__Scripts/Core/ConstellationManager.cs
+++ b/Assets/__Scripts/Core/ConstellationManager.cs
@@ -26,7 +26,7 @@ public class ConstellationManager : Singleton<ConstellationManager>
 
 			if (OnStartAnimation)
 			{
-				con.AnimateLines(() =>
+				con.AnimateLinesOpen(() =>
 				{
 					con.AnimateImage();
 				});
@@ -55,20 +55,13 @@ public class ConstellationManager : Singleton<ConstellationManager>
 		}
 		if (Input.GetKeyDown(KeyCode.Alpha3))
 		{
-			RevertAnimation(0);
+			AnimateImage(1);
 		}
 		if (Input.GetKeyDown(KeyCode.Alpha4))
 		{
-			AnimateImage(1);
-		}
-		if (Input.GetKeyDown(KeyCode.Alpha5))
-		{
 			AnimateLines(1);
 		}
-		if (Input.GetKeyDown(KeyCode.Alpha6))
-		{
-			RevertAnimation(1);
-		}
+
 	}
 
 
@@ -79,11 +72,7 @@ public class ConstellationManager : Singleton<ConstellationManager>
 	}
 	public void AnimateLines(int i)
 	{
-		constellations[i].AnimateLines();
-	}
-	public void RevertAnimation(int i)
-	{
-		constellations[i].RevertAnimation();
+		constellations[i].ToggleAnimations();
 	}
 
 }

--- a/Assets/__Scripts/Core/FpsCameraController3D.cs
+++ b/Assets/__Scripts/Core/FpsCameraController3D.cs
@@ -5,8 +5,8 @@ public class FpsCameraController3D : MonoBehaviour
     [SerializeField] private Transform camTransform;
     [SerializeField] private Vector2 rotationSens;
 
-	private float xRotation = -50;
-	private float yRotation = 100;
+	private float xRotation = -42;
+	private float yRotation = 117;
 
 
     private void Awake()

--- a/Assets/__Scripts/Core/MeshCombiner.cs
+++ b/Assets/__Scripts/Core/MeshCombiner.cs
@@ -16,6 +16,12 @@ public class MeshCombiner : MonoBehaviour
 		meshSchemas[i].filters.AddRange(filters);
 	}
 
+	public void CombineAllMeshes(Transform parent = null)
+	{
+		for (int i = 0; i < meshSchemas.Length; i++)
+			CombineMeshes(i, parent);
+	}
+
 	public void CombineMeshes(int i, Transform parent = null)
 	{
 		CombineMeshes(meshSchemas[i].material, meshSchemas[i].filters, meshSchemas[i].name, parent);
@@ -33,6 +39,8 @@ public class MeshCombiner : MonoBehaviour
 		}
 
 		// Присваиваем новый меш главному объекту
+		if (parent == null)
+			parent = transform;
 		var mainParent = new GameObject(name, typeof(MeshFilter), typeof(MeshRenderer));
 		mainParent.transform.SetParent(parent);
 		MeshFilter filter = mainParent.GetComponent<MeshFilter>();

--- a/Assets/__Scripts/LineController.cs
+++ b/Assets/__Scripts/LineController.cs
@@ -5,21 +5,17 @@ using System;
 public class LineController : MonoBehaviour
 {
 	// Класс для управление поведением линией (в основной по части анимаций)
-
 	[SerializeField] 
 	public LineRenderer lineRenderer;
 
 	public bool IsEnabled;
-
+	public float Length;
 	private Vector3 from, to;
-	private bool isStretchAnimMode;
 
-	public void Init(bool isStretchMode)
+	public void Init()
 	{
 		// Иницилазиация
 		var lineColor = lineRenderer.material.color;
-		isStretchAnimMode = isStretchMode;
-		lineColor.a = isStretchMode ? 1 : 0;
 		lineRenderer.material.color = lineColor;
 		lineRenderer.startColor = lineColor;
 		lineRenderer.endColor = lineColor;
@@ -38,6 +34,8 @@ public class LineController : MonoBehaviour
 
 		from = fromPos + dir.normalized * lso;
 		to = toPos - dir.normalized * lso;
+
+		Length = (toPos - fromPos).magnitude;
 	}
 
 	public void RevertTarget()
@@ -50,13 +48,9 @@ public class LineController : MonoBehaviour
 
 	public void SetPosition()
 	{
-		// Выставляем рассчитанные в CalcPositions значения в объект lineRenderer
+		// Выставляем начальные значения для линий
 		lineRenderer.SetPosition(0, from);
-
-		if (isStretchAnimMode)
-			lineRenderer.SetPosition(1, from); 
-		else
-			lineRenderer.SetPosition(1, to);
+		lineRenderer.SetPosition(1, from);
 	}
 
 	public void StretchLine(float duration, Action OnComplete = null) => StartCoroutine(StretchLineCoroutine(duration, OnComplete));
@@ -64,7 +58,6 @@ public class LineController : MonoBehaviour
 	private IEnumerator StretchLineCoroutine(float duration, Action OnComplete = null)
 	{
 		// Корутина для анимации растягивания
-
 		if (lineRenderer.positionCount != 2)
 			yield break;
 

--- a/Assets/__Scripts/Not Monobehavior/Helper.cs
+++ b/Assets/__Scripts/Not Monobehavior/Helper.cs
@@ -63,26 +63,25 @@ public static class Helper
 
 	// Анимация увеличения параметра scale
 	// coefficient - число в (0,1), такое, что мы увеличиваемся duration * coefficient времени и уменьшаемся остальное время
-	public static IEnumerator ScaleBounceAnimation(Transform t, float duration, float scaleMultiplier, float coefficient = 0.5f)
+	public static IEnumerator ScaleBounceAnimation(Transform t, float duration, Vector3 initialScale, float scaleMultiplier, float coefficient = 0.5f)
 	{
 		if (duration == 0)
 			throw new ArgumentException("Duration can't be zero");
 
-		Vector3 initialScale = t.localScale;
 		Vector3 targetScale = initialScale * scaleMultiplier;
-		float elapsedTime = 0;
+
+
+		// Линейно интерполируем elapsedTime по текущему скейлу звезды, чтобы продолжить анимацию
+		float elapsedTime = (t.localScale.x - initialScale.x) / (targetScale.x - initialScale.x);
 		float shrinked = duration * coefficient;
 		while (elapsedTime < duration)
 		{
 			elapsedTime += Time.deltaTime;
 			if (elapsedTime < shrinked) // первую половину времени увеличиваемя, потом уменьшаемся. Если нужно поменять коэффциент, то надо менять и двойку ниже
-			{
-				t.localScale = Vector3.Lerp(initialScale, targetScale, elapsedTime / shrinked); // перенёс 1/2 из знаменателя
-			}
+				t.localScale = Vector3.Lerp(initialScale, targetScale, elapsedTime / shrinked);
 			else
-			{
 				t.localScale = Vector3.Lerp(targetScale, initialScale, elapsedTime / shrinked - 1);
-			}
+
 			yield return null;
 		}
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.collab-proxy": "2.5.2",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.memoryprofiler": "1.1.1",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -60,6 +60,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.memoryprofiler": {
+      "version": "1.1.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.editorcoroutines": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.performance.profile-analyzer": {
       "version": "1.2.2",
       "depth": 1,


### PR DESCRIPTION
…or code.

Performance: Now only 6 drawcalls are registered on the Idle vs 178 in the orginial version and 63 when everything is on. Animations: Now properly reverts animation
Refactor:
1) ScaleBounce helper coroutine now accept initialScale to support correct "bounce" effect 2) Now "dynamic" and "static" stars are created separately. Static stars are merged into a single mesh and then destroyed. Dynamic stars exist as gameobjects and disabled when not in use 3) Removed "Fade" animation